### PR TITLE
Fix incorrect bool

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -652,7 +652,7 @@ static void winMainImpl(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstan
             }
 
             deviceContext->UpdateSubresource(constantBuffer.get(), 0, nullptr, &data, 0, 0);
-            constantBufferInvalidated = true;
+            constantBufferInvalidated = false;
         }
 
         {


### PR DESCRIPTION
The `constantBufferInvalidated` variable looks like it's currently always true right now, I think it should be flipping it to false after the uniform gets updated?